### PR TITLE
fix: hacs validation

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,14 +2,17 @@ name: HACS Validation
 
 on:
   push:
-    branches:
-      - main
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
 jobs:
   hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Checkout
-        uses: "actions/checkout@v2"
       - name: Validate HACS
         uses: "hacs/action@main"
         with:

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,5 @@
     "content_in_root": false,
     "filename": "energy-period-selector-plus.js",
     "render_readme": true,
-    "domains": ["lovelace"],
     "homeassistant": "2023.1.0"
 }


### PR DESCRIPTION
## Summary
- Removes an invalid key from `hacs.json` for plugin validation.
- Updates HACS workflow triggers so validation runs on pull requests, pushes, manual dispatch, and schedule.

## Test plan
- [x] Run HACS validation on `fix/hacs-validation`.
- [x] Confirm HACS checks pass (7/7).
- [x] Merge PR and verify workflow on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes: expands when HACS validation runs and removes an invalid `hacs.json` key, with no runtime impact on the plugin.
> 
> **Overview**
> Fixes HACS validation by removing the unsupported `domains` field from `hacs.json`.
> 
> Updates the GitHub Actions HACS validation workflow to run on `pull_request`, scheduled, and manual dispatch events (in addition to pushes), and explicitly sets `permissions: {}` for the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e25d2fa86f1d5637b3af4ec8f3d241b967db40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->