### PR TITLE
fix: support immutable github releases

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -62,7 +62,7 @@ jobs:
           retention-days: 30
 
   release:
-    name: Create Release
+    name: Create and Publish Release
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -76,13 +76,18 @@ jobs:
           name: dist-files
           path: dist/
           
-      - name: Create Release
+      - name: Create Draft Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             dist/energy-period-selector-plus.js
           generate_release_notes: true
-          draft: false
+          draft: true
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Release
+        run: gh release edit "${{ github.ref_name }}" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Creates releases as drafts first so the asset upload succeeds with immutable releases enabled.
- Publishes the draft release after asset upload completes.
- Keeps autogenerated release notes and tag-driven release flow unchanged.

## Test plan
- [ ] Merge this PR.
- [ ] Create and push the next version tag (for example `v0.2.7`).
- [ ] Confirm release is published and includes `energy-period-selector-plus.js` asset.