### PR TITLE
chore: auto-detect prerelease tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -75,6 +75,16 @@ jobs:
         with:
           name: dist-files
           path: dist/
+
+      # Hyphen in tag (e.g. v0.2.8-beta.1, v0.2.8-rc.1) → prerelease.
+      - name: Determine release channel
+        id: release_channel
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
           
       - name: Create Draft Release
         uses: softprops/action-gh-release@v1
@@ -83,7 +93,7 @@ jobs:
             dist/energy-period-selector-plus.js
           generate_release_notes: true
           draft: true
-          prerelease: false
+          prerelease: ${{ steps.release_channel.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,7 +7,8 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: validate-${{ github.workflow }}-${{ github.ref }}
@@ -17,7 +18,19 @@ jobs:
   hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Validate HACS
-        uses: "hacs/action@main"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate HACS on default branch
+        if: github.ref_name == github.event.repository.default_branch
+        uses: hacs/action@main
         with:
-          category: "plugin"
+          category: plugin
+
+      - name: Validate HACS on non-default branches
+        if: github.ref_name != github.event.repository.default_branch
+        uses: hacs/action@main
+        with:
+          category: plugin
+          # hacsjson + images wrongly validate default-branch content on non-default refs (hacs/integration#3362, #3822, #4629). To be removed when action image includes fix.
+          ignore: hacsjson images


### PR DESCRIPTION
## 📝 Description

- **HACS validation:** Add `contents: read`, checkout step, and split into two steps: full validation on the default branch; on other branches run with `ignore: "hacsjson images"` (workaround for wrong-ref behaviour; see hacs/integration#3362, #3822, #4629).
- **Release:** Tags with a hyphen (e.g. `v0.2.8-rc.1`, `v0.2.8-beta.2`) create prereleases; others create full releases.
- **README:** Shorten install section; fix "behaviour" → "behavior" and minor wording/punctuation.

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧰 Maintenance (dependencies, config, etc.)
- [ ] 🧪 Tests
- [ ] 🏗️ Build system changes

## 🧪 Testing

- [x] I have tested this change locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## 📋 Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🔗 Related Issues

Related to hacs/integration#3362, #3822, #4629.

## 📸 Screenshots (if applicable)

N/A

## 📝 Additional Notes

Remove the `ignore` in `validate.yaml` once the HACS action image includes the ref fix.