### PR TITLE
docs: Updated documentation URL for customcard

### DIFF
--- a/src/utils/register-custom-card.ts
+++ b/src/utils/register-custom-card.ts
@@ -12,6 +12,6 @@ export function registerCustomCard(params: RegisterCardParams) {
     windowWithCards.customCards.push({
         ...params,
         preview: true,
-        documentationURL: `https://github.com/flixlix/energy-period-selector-plus`,
+        documentationURL: `https://github.com/talKitron/energy-period-selector-plus`,
     });
 }


### PR DESCRIPTION
## 📝 Description

Updated documentationURL to point to talKitron/energy-period-selector-plus, instead of flixlix.

## 🔧 Type of Change

- [x] 🧰 Maintenance (dependencies, config, etc.)

## 🧪 Testing

Not tested.

## Notes

While configuring the card in HA, I kept opening the older flixlix repo via the link in HA, instead of talKitron.